### PR TITLE
removed illegal partition assign from input.py

### DIFF
--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -498,14 +498,12 @@ class ConfluentKafkaInput(Input):
         for topic_partition in topic_partitions:
             self.metrics.number_of_warnings += 1
             logger.warning(
-                "%s has lost topic: %s | partition %s - try to reassign",
+                "%s has lost topic: %s | partition %s",
                 consumer.memberid(),
                 topic_partition.topic,
                 topic_partition.partition,
             )
-            topic_partition.offset = OFFSET_STORED
-        self._consumer.assign(topic_partitions)
-
+            
     def shut_down(self) -> None:
         """Close consumer, which also commits kafka offsets."""
         self._consumer.close()


### PR DESCRIPTION
Die für einen subscription based consumer illegale Operation "assign(topic_partition)" aus _lost_callback entfernt.
Ggf. muss noch irgendwas aufgeräumt werden. 
Da diese Partitionen potentiell bereits von einem anderen Consumer bearbeitet werden, passt "batch_finished" nicht. Das könnte zu Chaos bei den Offsets führen.
Ob ein "output_connector._write_backlog" Chaos auf der Output Seite auslösen kann, kann ich nicht beurteilen.